### PR TITLE
Support Actix Web 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-middleware-redirect-scheme"
-version = "2.3.3"
+version = "3.0.0"
 description = "A middleware for actix-web which forwards all `http` requests to `https` and vice versa. Based on actix-web-middleware-redirect-https."
 authors = ["Peter Trotman <petertrotman@gmail.com>", "Захаров Константин Иванович <konstantin_1987@mail.ru>"]
 edition = "2018"
@@ -12,8 +12,8 @@ keywords = ["actix-web", "middleware", "redirect", "https", "ssl"]
 categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
-actix-service = "1.0.5"
-actix-web = "2.0.0"
+actix-service = "1.0.6"
+actix-web = "3"
 futures = "0.3"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming", "web-programming::http-server"]
 
 [dependencies]
 actix-service = "1.0.6"
-actix-web = "3"
+actix-web = { version = "3.0", default-features = false }
 futures = "0.3"
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A middleware for actix-web which forwards all `http` requests to `https` and vic
 ```toml
 # Cargo.toml
 [dependencies]
-actix-web-middleware-redirect-scheme = "2.3"
+actix-web-middleware-redirect-scheme = "3"
 ```
 
 ```rust
@@ -83,7 +83,7 @@ App::new()
 ```toml
 # Cargo.toml
 [dependencies]
-actix-web-middleware-redirect-scheme = "2.3"
+actix-web-middleware-redirect-scheme = "3"
 ```
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A middleware for actix-web which forwards all `http` requests to `https` and vic
 ```toml
 # Cargo.toml
 [dependencies]
-actix-web-middleware-redirect-scheme = "3"
+actix-web-middleware-redirect-scheme = "3.0"
 ```
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! actix-web-middleware-redirect-scheme = "2.3"
+//! actix-web-middleware-redirect-scheme = "3"
 //! ```
 //!
 //! ```rust
@@ -92,7 +92,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! actix-web-middleware-redirect-scheme = "2.3"
+//! actix-web-middleware-redirect-scheme = "3"
 //! ```
 //!
 //! ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! actix-web-middleware-redirect-scheme = "3"
+//! actix-web-middleware-redirect-scheme = "3.0"
 //! ```
 //!
 //! ```rust


### PR DESCRIPTION
Hi,

Please take a look at my forked version of your plugin. I updated the dependencies to support Actix Web version 3, which was released two days ago. I decided that a bump of the major version would be the best option since Actix Web 2 and 3 are not fully compatible. This bumps your plugin to version 3.0.0.